### PR TITLE
Simplify the PHPUnit's call to the autoloader.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once (realpath(__DIR__.'/../vendor/autoload.php'));


### PR DESCRIPTION
This reduces the number of files on the filesystem.

If we determine that additional information is needed in the bootstrap file that cannot be placed in `phpunit.xml`, then I can foresee creating a `bootstrap.php` to fit that need.
